### PR TITLE
Use postgres full-text search abilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ ructe = { version = "0.13", features = ["sass", "warp02"] }
 [dependencies]
 anyhow = "1.0"
 chrono = "0.4.6"
+diesel_full_text_search = { git = "https://github.com/diesel-rs/diesel_full_text_search" }
 dotenv = "0.15.0"
 env_logger = "0.7.1"
 log = "0.4.8"

--- a/migrations/2020-05-10-122201_searchvector/down.sql
+++ b/migrations/2020-05-10-122201_searchvector/down.sql
@@ -1,0 +1,10 @@
+
+drop trigger episode_ts_update on episodes;
+drop trigger article_ts_update on articles;
+
+drop function episodes_trigger;
+drop function articles_trigger;
+drop function make_tsv;
+
+alter table episodes drop column ts;
+alter table articles drop column ts;

--- a/migrations/2020-05-10-122201_searchvector/up.sql
+++ b/migrations/2020-05-10-122201_searchvector/up.sql
@@ -1,0 +1,49 @@
+
+alter table episodes add column ts tsvector;
+alter table articles add column ts tsvector;
+
+create function make_tsv(s text) returns tsvector as $$
+   select to_tsvector(replace(coalesce(s, ''), U&'\00AD', ''))
+$$ language sql;
+
+update episodes set ts =
+   setweight(make_tsv(episode), 'A') ||
+   setweight(make_tsv(teaser), 'B') ||
+   setweight(make_tsv(note), 'C') ||
+   setweight(make_tsv(copyright), 'D');
+
+create function episodes_trigger() returns trigger as $$
+begin
+  new.ts :=
+   setweight(make_tsv(new.episode), 'A') ||
+   setweight(make_tsv(new.teaser), 'B') ||
+   setweight(make_tsv(new.note), 'C') ||
+   setweight(make_tsv(new.copyright), 'D');
+  return new;
+end
+$$ language plpgsql;
+
+
+update articles set ts =
+   setweight(make_tsv(title), 'A') ||
+   setweight(make_tsv(subtitle), 'A') ||
+   setweight(make_tsv(note), 'B');
+
+create function articles_trigger() returns trigger as $$
+begin
+  new.ts :=
+   setweight(make_tsv(new.title), 'A') ||
+   setweight(make_tsv(new.subtitle), 'A') ||
+   setweight(make_tsv(new.note), 'B');
+  return new;
+end
+$$ language plpgsql;
+
+create trigger episode_ts_update before insert or update
+on episodes for each row execute function episodes_trigger();
+
+create trigger article_ts_update before insert or update
+on articles for each row execute function articles_trigger();
+
+alter table episodes alter column ts set not null;
+alter table articles alter column ts set not null;

--- a/src/models/article.rs
+++ b/src/models/article.rs
@@ -15,6 +15,10 @@ pub struct Article {
 }
 
 impl Article {
+    #[allow(non_upper_case_globals)] // consistent with diesel
+    pub const columns: (a::id, a::title, a::subtitle, a::note) =
+        (a::id, a::title, a::subtitle, a::note);
+
     pub fn get_or_create(
         title: &str,
         subtitle: Option<&str>,
@@ -22,6 +26,7 @@ impl Article {
         db: &PgConnection,
     ) -> Result<Article, Error> {
         if let Some(article) = a::articles
+            .select(Article::columns)
             .filter(a::title.eq(title))
             .filter(a::subtitle.is_not_distinct_from(subtitle))
             .filter(a::note.is_not_distinct_from(note))
@@ -36,6 +41,7 @@ impl Article {
                     a::subtitle.eq(subtitle),
                     a::note.eq(note),
                 ))
+                .returning(Article::columns)
                 .get_result(db)?)
         }
     }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -7,11 +7,14 @@ table! {
 }
 
 table! {
+    use diesel::sql_types::*;
+    use diesel_full_text_search::TsVector;
     articles (id) {
         id -> Int4,
         title -> Varchar,
         subtitle -> Nullable<Varchar>,
         note -> Nullable<Text>,
+        ts -> TsVector,
     }
 }
 
@@ -75,6 +78,8 @@ table! {
 }
 
 table! {
+    use diesel::sql_types::*;
+    use diesel_full_text_search::TsVector;
     episodes (id) {
         id -> Int4,
         title -> Int4,
@@ -90,6 +95,7 @@ table! {
         orig_mag -> Nullable<Int4>,
         strip_from -> Nullable<Int4>,
         strip_to -> Nullable<Int4>,
+        ts -> TsVector,
     }
 }
 

--- a/src/server/creators.rs
+++ b/src/server/creators.rs
@@ -84,13 +84,13 @@ async fn one_creator(
     };
 
     let about_raw = a::articles
-        .select(a::articles::all_columns())
+        .select(Article::columns)
         .left_join(ar::article_refkeys.left_join(r::refkeys))
         .filter(r::kind.eq(RefKey::WHO_ID))
         .filter(r::slug.eq(creator.slug.clone()))
         .inner_join(p::publications.inner_join(i::issues))
         .order(min(i::magic))
-        .group_by(a::articles::all_columns())
+        .group_by(Article::columns)
         .load_async::<Article>(&db)
         .await
         .map_err(custom)?;
@@ -111,7 +111,7 @@ async fn one_creator(
         ));
     }
 
-    let e_t_columns = (t::titles::all_columns(), e::episodes::all_columns());
+    let e_t_columns = (t::titles::all_columns(), Episode::columns);
     let main_episodes_raw = e::episodes
         .inner_join(eb::episodes_by.inner_join(ca::creator_aliases))
         .inner_join(t::titles)
@@ -136,12 +136,12 @@ async fn one_creator(
     }
 
     let articles_by_raw = a::articles
-        .select(a::articles::all_columns())
+        .select(Article::columns)
         .inner_join(ab::articles_by.inner_join(ca::creator_aliases))
         .filter(ca::creator_id.eq(creator.id))
         .inner_join(p::publications.inner_join(i::issues))
         .order(min(i::magic))
-        .group_by(a::articles::all_columns())
+        .group_by(Article::columns)
         .load_async::<Article>(&db)
         .await
         .map_err(custom)?;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -407,11 +407,11 @@ async fn list_year(db: PgPool, year: u16) -> Result<impl Reply, Rejection> {
             .select((
                 (
                     t::titles::all_columns(),
-                    e::episodes::all_columns(),
+                    Episode::columns,
                     (ep::id, ep::part_no, ep::part_name),
                 )
                     .nullable(),
-                a::articles::all_columns().nullable(),
+                Article::columns.nullable(),
                 p::seqno,
                 p::best_plac,
                 p::label,

--- a/src/server/refs.rs
+++ b/src/server/refs.rs
@@ -144,12 +144,12 @@ async fn one_ref_impl(
     };
 
     let raw_articles = a::articles
-        .select(a::articles::all_columns())
+        .select(Article::columns)
         .left_join(ar::article_refkeys.left_join(r::refkeys))
         .filter(ar::refkey_id.eq(refkey.id))
         .inner_join(p::publications.inner_join(i::issues))
         .order(min(i::magic))
-        .group_by(a::articles::all_columns())
+        .group_by(Article::columns)
         .load_async::<Article>(&db)
         .await
         .map_err(custom)?;
@@ -175,7 +175,7 @@ async fn one_ref_impl(
         .left_join(er::episode_refkeys)
         .inner_join(t::titles)
         .filter(er::refkey_id.eq(refkey.id))
-        .select((t::titles::all_columns(), e::episodes::all_columns()))
+        .select((t::titles::all_columns(), Episode::columns))
         .inner_join(
             ep::episode_parts
                 .inner_join(p::publications.inner_join(i::issues)),

--- a/src/server/titles.rs
+++ b/src/server/titles.rs
@@ -91,13 +91,13 @@ async fn one_title(
         .map_err(custom_or_404)?;
 
     let articles_raw = a::articles
-        .select(a::articles::all_columns())
+        .select(Article::columns)
         .left_join(ar::article_refkeys.left_join(r::refkeys))
         .filter(r::kind.eq(RefKey::TITLE_ID))
         .filter(r::slug.eq(title.slug.clone()))
         .inner_join(p::publications.inner_join(i::issues))
         .order(min(i::magic))
-        .group_by(a::articles::all_columns())
+        .group_by(Article::columns)
         .load_async::<Article>(&db)
         .await
         .map_err(custom)?;
@@ -120,12 +120,12 @@ async fn one_title(
 
     let episodes = e::episodes
         .filter(e::title.eq(title.id))
-        .select(e::episodes::all_columns())
+        .select(Episode::columns)
         .inner_join(
             ep::episode_parts
                 .inner_join(p::publications.inner_join(i::issues)),
         )
-        .group_by(crate::schema::episodes::all_columns);
+        .group_by(Episode::columns);
 
     let episodes = match strip {
         Some(sun) => episodes

--- a/templates/search.rs.html
+++ b/templates/search.rs.html
@@ -41,20 +41,21 @@
   <section class="searchresults">
     <h2>Episoder och artiklar</h2>
     @for hit in hits {
-      @if let Hit::Episode{ title, fe } = hit {
-        <section class="episode @fe.bestclass()">
+      @match hit {
+        Hit::Episode{ title, fe, rank } => {
+        <section class="episode @fe.bestclass()" data-rank="@rank">
           <h3><a href="/titles/@title.slug">@title.title</a>@if let Some(ref h) = fe.episode.episode {: @h}</h3>
           @:epmisc(&fe)
         </section>
       }
-      @if let Hit::Article{ article, published } = hit {
-        <section class="article">
+      Hit::Article{ article, published, rank } => {
+        <section class="article" data-rank="@rank">
           @:artmisc(article)
           @if let Some((last_pub, pubs)) = published.split_last()
           {<p class="info pub">Publicerad i: @for p in pubs {@p, }@last_pub.</p>}
         </section>
       }
-    }
+    }}
   </section>
   }
 })


### PR DESCRIPTION
Tsvector columns is added to tables _episodes_ and _articles_, and kept up-to-date with triggers.

Things to consider:

* [ ] Use stored generated columns instead of triggers?  Requires updated postgresql.
* [ ] The `websearch_to_tsquery` function is available in diesel_full_text_search on the master branch, but not yet released.