### PR TITLE
Year summary + single issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = "1.0"
 chrono = "0.4.6"
 dotenv = "0.15.0"
 env_logger = "0.8"
+futures = "0.3" # Must match warp
 log = "0.4.8"
 lazy_static = "1.4.0"
 mime = "0.3"

--- a/res/style.scss
+++ b/res/style.scss
@@ -477,71 +477,84 @@ section.articles {
 }
 
 
-@media (min-width: 35em) {
-    div.yearsummary {
-        flex-flow: row wrap;
-        display: flex;
-        margin: .7em -.3em;
-        align-items: start;
+div.yearsummary {
+    flex-flow: row wrap;
+    display: flex;
+    margin: .7em -.3em;
+    align-items: start;
 
-        .issue {
-            margin: .3em;
-            flex: 24em 1 1;
-            display: grid;
-            grid-auto-columns: 10em auto;
-            grid-gap: .3em;
+    .issue {
+        margin: .3em;
+        flex: 24em 1 1;
+        display: grid;
+        grid-auto-columns: 2fr 1fr;
+        overflow: hidden;
+        grid-gap: .3em;
 
-            > header {
-                grid-column: 1 / 3;
-                display: flex;
-                flex-flow: row wrap;
-                align-items: baseline;
-                justify-content: space-between;
-                p {
-                    margin: 0;
-                }
-            }
-            .info.cover {
-                grid-column: 1 / 2;
-                width: 10em;
-                .img, img {
-                    width: -moz-available;
-                    display: block;
-                }
-                p {
-                    font-size: 90%;
-                    margin: 0;
-                }
-            }
-            .content {
-                grid-column: 2 / 3;
+        > header {
+            display: flex;
+            flex-flow: row wrap;
+            align-items: baseline;
+            justify-content: space-between;
+            p {
                 margin: 0;
-                padding: 0;
+            }
+        }
+        .info.cover {
+            overflow: hidden;
+            .img, img {
+                width: -moz-available;
+                display: block;
+            }
+            p {
+                font-size: 90%;
+                margin: 0;
+            }
+        }
+        .content {
+            grid-column: 1 / 3;
+            margin: 0;
+            padding: 0;
 
-                ul {
-                    font-size: 90%;
-                    background: rgba(255,255,255,0.4);
-                    margin: 0;
-                    border-radius: .3em;
-                    padding: .3em .3em .3em 1.2em;
-                    width: -moz-available;
-                }
+            ul {
+                font-size: 90%;
+                background: rgba(255,255,255,0.4);
+                margin: 0;
+                border-radius: .3em;
+                padding: .3em .3em .3em 1.2em;
+                width: -moz-available;
             }
         }
     }
+}
 
-    p.yearcovers {
-        text-align: center;
-        line-height: 11vw;
-        margin-top: -6vw;
-        img {
-            width: 3vw;
-            transition: width 500ms;
-            vertical-align: bottom;
+@media (min-width: 25em) {
+    div.yearsummary .issue {
+        grid-auto-columns: 10em auto;
+        > header {
+            grid-column: 1 / 3;
         }
-        img:hover, a:focus img {
-            width: 7vw;
-            transition: width 100ms;
+        .info.cover {
+            grid-column: 1 / 2;
+            width: 10em;
         }
+        .content {
+            grid-column: 2 / 3;
+        }
+    }
+}
+
+p.yearcovers {
+    text-align: center;
+    line-height: 11vw;
+    margin-top: -6vw;
+    img {
+        width: 3vw;
+        transition: width 500ms;
+        vertical-align: bottom;
+    }
+    img:hover, a:focus img {
+        width: 7vw;
+        transition: width 100ms;
     }
 }

--- a/res/style.scss
+++ b/res/style.scss
@@ -183,7 +183,7 @@ div.cover {
 	    margin: 0;
 	    padding: 0;
 	    position: absolute;
-	    right: -.3em;
+	    right: 0;
 	    width: 1.9rem;
 	}
     }

--- a/res/style.scss
+++ b/res/style.scss
@@ -475,3 +475,73 @@ section.articles {
         flex-grow:1;
     }
 }
+
+
+@media (min-width: 35em) {
+    div.yearsummary {
+        flex-flow: row wrap;
+        display: flex;
+        margin: .7em -.3em;
+        align-items: start;
+
+        .issue {
+            margin: .3em;
+            flex: 24em 1 1;
+            display: grid;
+            grid-auto-columns: 10em auto;
+            grid-gap: .3em;
+
+            > header {
+                grid-column: 1 / 3;
+                display: flex;
+                flex-flow: row wrap;
+                align-items: baseline;
+                justify-content: space-between;
+                p {
+                    margin: 0;
+                }
+            }
+            .info.cover {
+                grid-column: 1 / 2;
+                width: 10em;
+                .img, img {
+                    width: -moz-available;
+                    display: block;
+                }
+                p {
+                    font-size: 90%;
+                    margin: 0;
+                }
+            }
+            .content {
+                grid-column: 2 / 3;
+                margin: 0;
+                padding: 0;
+
+                ul {
+                    font-size: 90%;
+                    background: rgba(255,255,255,0.4);
+                    margin: 0;
+                    border-radius: .3em;
+                    padding: .3em .3em .3em 1.2em;
+                    width: -moz-available;
+                }
+            }
+        }
+    }
+
+    p.yearcovers {
+        text-align: center;
+        line-height: 11vw;
+        margin-top: -6vw;
+        img {
+            width: 3vw;
+            transition: width 500ms;
+            vertical-align: bottom;
+        }
+        img:hover, a:focus img {
+            width: 7vw;
+            transition: width 100ms;
+        }
+    }
+}

--- a/src/models/issue.rs
+++ b/src/models/issue.rs
@@ -111,6 +111,10 @@ impl Issue {
             .execute(db)?;
         Ok(())
     }
+    /// Site-relative url to the cover image of this issue.
+    pub fn cover_url(&self) -> String {
+        format!("/c/f{}-{}.jpg", self.year, self.number)
+    }
 }
 
 impl fmt::Display for Issue {

--- a/src/models/issue.rs
+++ b/src/models/issue.rs
@@ -226,7 +226,7 @@ impl ToHtml for IssueRef {
     fn to_html(&self, out: &mut dyn Write) -> io::Result<()> {
         write!(
             out,
-            "<a href='/{y}#i{n}'><span class='ifwide'>Fa</span> \
+            "<a href='/{y}/{n}'><span class='ifwide'>Fa</span> \
              {ns}\u{200b}/{y}</a>",
             y = self.year,
             n = self.number.number,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -420,18 +420,6 @@ async fn issue(
     Builder::new().html(|o| templates::issue(o, &years, &details, &pubyear))
 }
 
-async fn cover_by(
-    issue_id: i32,
-    db: &PgPool,
-) -> Result<Vec<Creator>, AsyncError> {
-    c::creators
-        .inner_join(ca::creator_aliases.inner_join(cb::covers_by))
-        .select((c::id, ca::name, c::slug))
-        .filter(cb::issue_id.eq(issue_id))
-        .load_async(&db)
-        .await
-}
-
 async fn list_year(db: PgPool, year: u16) -> Result<impl Reply, Rejection> {
     use futures::stream::{self, StreamExt, TryStreamExt};
     let issues = i::issues
@@ -540,6 +528,18 @@ impl IssueDetails {
             contents,
         })
     }
+}
+
+async fn cover_by(
+    issue_id: i32,
+    db: &PgPool,
+) -> Result<Vec<Creator>, AsyncError> {
+    c::creators
+        .inner_join(ca::creator_aliases.inner_join(cb::covers_by))
+        .select((c::id, ca::name, c::slug))
+        .filter(cb::issue_id.eq(issue_id))
+        .load_async(&db)
+        .await
 }
 
 fn custom_or_404(e: AsyncError) -> Rejection {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -5,6 +5,7 @@ mod publist;
 mod refs;
 pub mod search;
 mod titles;
+mod yearsummary;
 
 use self::covers::{cover_image, redirect_cover};
 pub use self::creators::CoverSet;
@@ -12,10 +13,11 @@ pub use self::paginator::Paginator;
 pub use self::publist::{OtherContribs, PartsPublished};
 use self::refs::{get_all_fa, one_fa};
 use self::search::{search, search_autocomplete};
+pub use yearsummary::ContentSummary;
 
 use crate::models::{
-    Article, Creator, CreatorSet, Episode, Issue, OtherMag, Part, RefKey,
-    RefKeySet, Title,
+    Article, Creator, CreatorSet, Episode, Issue, IssueRef, OtherMag, Part,
+    RefKey, RefKeySet, Title,
 };
 use crate::schema::articles::dsl as a;
 use crate::schema::covers_by::dsl as cb;
@@ -112,7 +114,23 @@ impl Args {
                 .and(path("robots.txt"))
                 .and(end())
                 .and_then(robots_txt))
-            .or(goh().and(s()).and(param()).and(end()).and_then(list_year))
+            .or(goh()
+                .and(s())
+                .and(param())
+                .and(end())
+                .and_then(yearsummary::year_summary))
+            .or(goh()
+                .and(s())
+                .and(param())
+                .and(param())
+                .and(end())
+                .and_then(issue))
+            .or(goh()
+                .and(s())
+                .and(param())
+                .and(path("details"))
+                .and(end())
+                .and_then(list_year))
             .or(goh()
                 .and(s())
                 .and(param())
@@ -332,7 +350,7 @@ fn text_to_fa_html(text: &str) -> Html<String> {
         .replace('&', "&amp;")
         .replace('<', "&lt;")
         .replace('>', "&gt;");
-    let html = FA.replace_all(&html, "<a href='/$y#i$i'>Fa $ii/$y</a>");
+    let html = FA.replace_all(&html, "<a href='/$y/$i'>Fa $ii/$y</a>");
     let html = URL.replace_all(&html, "<a href='$p://$l'>$l</a>");
     Html(html.to_string())
 }
@@ -357,14 +375,14 @@ fn text_to_fa_html_b() {
 fn text_to_fa_html_c() {
     assert_eq!(
         text_to_fa_html("See Fa 7 1980.").0,
-        "See <a href='/1980#i7'>Fa 7/1980</a>.",
+        "See <a href='/1980/7'>Fa 7/1980</a>.",
     )
 }
 #[test]
 fn text_to_fa_html_d() {
     assert_eq!(
         text_to_fa_html("See Fa 25-26/2019.").0,
-        "See <a href='/2019#i25'>Fa 25-26/2019</a>.",
+        "See <a href='/2019/25'>Fa 25-26/2019</a>.",
     )
 }
 
@@ -374,6 +392,113 @@ fn text_to_fa_html_e() {
         text_to_fa_html("See https://rasmus.krats.se .").0,
         "See <a href='https://rasmus.krats.se'>rasmus.krats.se</a> .",
     )
+}
+
+async fn issue(
+    db: PgPool,
+    year: u16,
+    issue: u8,
+) -> Result<impl Reply, Rejection> {
+    let issue: Issue = i::issues
+        .filter(i::year.eq(year as i16))
+        .filter(i::number.eq(i16::from(issue)))
+        .first_async(&db)
+        .await
+        .map_err(custom_or_404)?;
+
+    let pubyear = i::issues
+        .select((i::year, (i::number, i::number_str)))
+        .filter(i::year.eq(issue.year))
+        .order(i::number)
+        .load_async::<IssueRef>(&db)
+        .await
+        .map_err(custom)?;
+
+    let c_columns = (c::id, ca::name, c::slug);
+    let cover_by = c::creators
+        .inner_join(ca::creator_aliases.inner_join(cb::covers_by))
+        .select(c_columns)
+        .filter(cb::issue_id.eq(issue.id))
+        .load_async(&db)
+        .await
+        .map_err(custom)?;
+
+    let mut have_main = false;
+    let content_raw = p::publications
+        .left_outer_join(
+            ep::episode_parts.inner_join(e::episodes.inner_join(t::titles)),
+        )
+        .left_outer_join(a::articles)
+        .select((
+            (
+                t::titles::all_columns(),
+                e::episodes::all_columns(),
+                (ep::id, ep::part_no, ep::part_name),
+            )
+                .nullable(),
+            a::articles::all_columns().nullable(),
+            p::seqno,
+            p::best_plac,
+            p::label,
+        ))
+        .filter(p::issue.eq(issue.id))
+        .order(p::seqno)
+        .load_async::<(
+            Option<(Title, Episode, Part)>,
+            Option<Article>,
+            Option<i16>,
+            Option<i16>,
+            String,
+        )>(&db)
+        .await
+        .map_err(custom)?;
+    let mut contents = Vec::with_capacity(content_raw.len());
+    for row in content_raw.into_iter() {
+        match row {
+            (Some((t, mut e, part)), None, seqno, b, label) => {
+                let classnames = if e.teaser.is_none() || !part.is_first() {
+                    e.teaser = None;
+                    "episode noteaser"
+                } else if t.title == "Fantomen" && !have_main {
+                    have_main = true;
+                    "episode main"
+                } else {
+                    "episode"
+                };
+                let content = PublishedContent::EpisodePart {
+                    title: t,
+                    episode: FullEpisode::in_issue(e, &issue, &db)
+                        .await
+                        .map_err(custom)?,
+                    part,
+                    best_plac: b,
+                    label,
+                };
+                contents.push(PublishedInfo {
+                    content,
+                    seqno,
+                    classnames,
+                });
+            }
+            (None, Some(a), seqno, None, _label) => {
+                contents.push(PublishedInfo {
+                    content: PublishedContent::Text(
+                        FullArticle::load_async(a, &db)
+                            .await
+                            .map_err(custom)?,
+                    ),
+                    seqno,
+                    classnames: "article",
+                });
+            }
+            row => panic!("Strange row: {:?}", row),
+        }
+    }
+
+    let years = YearLinks::load(year, db).await?.link_current();
+    Builder::new().html(|o| {
+        templates::issue(o, &years, &issue, &cover_by, &contents, &pubyear)
+    })
 }
 
 async fn list_year(db: PgPool, year: u16) -> Result<impl Reply, Rejection> {
@@ -472,12 +597,7 @@ async fn list_year(db: PgPool, year: u16) -> Result<impl Reply, Rejection> {
         }
         issues.push((issue, cover_by, contents));
     }
-    let years = i::issues
-        .select((sql::<SmallInt>("min(year)"), sql::<SmallInt>("max(year)")))
-        .first_async::<(i16, i16)>(&db)
-        .await
-        .map_err(custom)?;
-    let years = YearLinks::new(years.0 as u16, year, years.1 as u16);
+    let years = YearLinks::load(year, db).await?;
     Builder::new().html(|o| templates::year(o, year, &years, &issues))
 }
 
@@ -521,11 +641,32 @@ pub struct YearLinks {
     first: u16,
     shown: u16,
     last: u16,
+    link_current: bool,
 }
 
 impl YearLinks {
+    async fn load(year: u16, db: PgPool) -> Result<Self, Rejection> {
+        let (first, last) = i::issues
+            .select((
+                sql::<SmallInt>("min(year)"),
+                sql::<SmallInt>("max(year)"),
+            ))
+            .first_async::<(i16, i16)>(&db)
+            .await
+            .map_err(custom)?;
+        Ok(YearLinks::new(first as u16, year, last as u16))
+    }
     fn new(first: u16, shown: u16, last: u16) -> Self {
-        YearLinks { first, shown, last }
+        YearLinks {
+            first,
+            shown,
+            last,
+            link_current: false,
+        }
+    }
+    fn link_current(mut self) -> Self {
+        self.link_current = true;
+        self
     }
 }
 
@@ -534,7 +675,11 @@ impl ToHtml for YearLinks {
         let shown = self.shown;
         let one = |out: &mut dyn Write, y: u16| -> io::Result<()> {
             if y == shown {
-                write!(out, "<b>{}</b>", y)?;
+                if self.link_current {
+                    write!(out, "<a href='/{}'><b>{}</b></a>", y, y)?;
+                } else {
+                    write!(out, "<b>{}</b>", y)?;
+                }
             } else {
                 write!(out, "<a href='/{}'>{}</a>", y, y)?;
             }

--- a/src/server/yearsummary.rs
+++ b/src/server/yearsummary.rs
@@ -1,0 +1,156 @@
+//use self::covers::{cover_image, redirect_cover};
+//pub use self::creators::CoverSet;
+//pub use self::paginator::Paginator;
+//pub use self::publist::{OtherContribs, PartsPublished};
+//use self::refs::{get_all_fa, one_fa};
+//use self::search::{search, search_autocomplete};
+use super::{custom, PgPool, YearLinks};
+use crate::models::Issue;
+use crate::schema::articles::dsl as a;
+use crate::schema::covers_by::dsl as cb;
+use crate::schema::creator_aliases::dsl as ca;
+use crate::schema::creators::dsl as c;
+use crate::schema::episode_parts::dsl as ep;
+use crate::schema::episodes::dsl as e;
+use crate::schema::issues::dsl as i;
+use crate::schema::publications::dsl as p;
+use crate::schema::titles::dsl as t;
+use crate::templates::{self, RenderRucte, ToHtml};
+//use diesel::dsl::{not, sql};
+//use diesel::pg::PgConnection;
+use diesel::prelude::*;
+//use diesel::r2d2::{ConnectionManager, Pool, PoolError};
+//use diesel::sql_types::SmallInt;
+use diesel::QueryDsl;
+//use lazy_static::lazy_static;
+//use mime::TEXT_PLAIN;
+//use regex::Regex;
+use std::io::{self, Write};
+use tokio_diesel::AsyncRunQueryDsl;
+//use warp::filters::BoxedFilter;
+//use warp::http::header::{CONTENT_TYPE, EXPIRES};
+use warp::http::response::Builder;
+//use warp::http::status::StatusCode;
+//use warp::path::Tail;
+//use warp::reply::Response;
+use warp::{self, reject::not_found, Rejection, Reply};
+
+pub async fn year_summary(
+    db: PgPool,
+    year: u16,
+) -> Result<impl Reply, Rejection> {
+    let issues_raw: Vec<Issue> = i::issues
+        .filter(i::year.eq(year as i16))
+        .order(i::number)
+        .load_async(&db)
+        .await
+        .map_err(custom)?;
+    if issues_raw.is_empty() {
+        return Err(not_found());
+    }
+    let mut issues = Vec::with_capacity(issues_raw.len());
+    for issue in issues_raw.into_iter() {
+        let cover_by = c::creators
+            .inner_join(ca::creator_aliases.inner_join(cb::covers_by))
+            .select((c::id, ca::name, c::slug))
+            .filter(cb::issue_id.eq(issue.id))
+            .load_async(&db)
+            .await
+            .map_err(custom)?;
+
+        let contents = p::publications
+            .left_outer_join(
+                ep::episode_parts
+                    .inner_join(e::episodes.inner_join(t::titles)),
+            )
+            .left_outer_join(a::articles)
+            .select((
+                (t::slug, t::title, e::episode, ep::part_no, ep::part_name)
+                    .nullable(),
+                (a::title, a::subtitle).nullable(),
+            ))
+            .filter(p::issue.eq(issue.id))
+            .order(p::seqno)
+            .load_async::<(Option<ComicSummary>, Option<ArticleSummary>)>(&db)
+            .await
+            .map_err(custom)?
+            .into_iter()
+            .map(|i| match i {
+                (Some(c), None) => ContentSummary::Comic(c),
+                (None, Some(a)) => ContentSummary::Text(a),
+                _ => unreachable!(),
+            })
+            .collect::<Vec<_>>();
+        issues.push((issue, cover_by, contents));
+    }
+    let years = YearLinks::load(year, db).await?;
+    Builder::new().html(|o| templates::year_summary(o, year, &years, &issues))
+}
+
+pub enum ContentSummary {
+    Comic(ComicSummary),
+    Text(ArticleSummary),
+}
+
+impl ToHtml for ContentSummary {
+    fn to_html(&self, out: &mut dyn Write) -> io::Result<()> {
+        match self {
+            ContentSummary::Comic(c) => c.to_html(out),
+            ContentSummary::Text(a) => a.to_html(out),
+        }
+    }
+}
+
+#[derive(Debug, Queryable)]
+pub struct ComicSummary {
+    slug: String,
+    title: String,
+    episode: Option<String>,
+    part_no: Option<i16>,
+    part_name: Option<String>,
+}
+
+// <strong><a href="/titles/slug">title</a>[episode]</strong> [part]
+impl ToHtml for ComicSummary {
+    fn to_html(&self, out: &mut dyn Write) -> io::Result<()> {
+        write!(out, "<strong><a href='/titles/{}'>", self.slug)?;
+        self.title.to_html(out)?;
+        out.write_all(b"</a>")?;
+        if let Some(episode) = &self.episode {
+            out.write_all(b": ")?;
+            episode.to_html(out)?;
+        }
+        out.write_all(b"</strong>")?;
+        if self.part_no.is_some() || self.part_name.is_some() {
+            out.write_all(b" <span class='part'>")?;
+            if let Some(no) = self.part_no {
+                write!(out, "del {}", no)?;
+                if self.part_name.is_some() {
+                    out.write_all(b": ")?;
+                }
+            }
+            if let Some(ref name) = &self.part_name {
+                name.to_html(out)?;
+            }
+            out.write_all(b"</span>")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Queryable)]
+pub struct ArticleSummary {
+    title: String,
+    subtitle: Option<String>,
+}
+// @article.title@if let Some(ref s) = article.subtitle {: @s}}
+impl ToHtml for ArticleSummary {
+    fn to_html(&self, out: &mut dyn Write) -> io::Result<()> {
+        self.title.to_html(out)?;
+        if let Some(subtitle) = &self.subtitle {
+            out.write_all(b": ")?;
+            subtitle.to_html(out)?;
+        }
+        Ok(())
+    }
+}

--- a/templates/issue.rs.html
+++ b/templates/issue.rs.html
@@ -1,39 +1,39 @@
-@use crate::models::{Creator, Issue, IssueRef};
-@use crate::server::{PublishedInfo, PublishedContent::{EpisodePart, Text}, YearLinks};
+@use crate::models::{IssueRef};
+@use crate::server::{IssueDetails, PublishedContent::{EpisodePart, Text}, YearLinks};
 @use super::{artmisc, epmisc, page};
 
-@(year_links: &YearLinks, issue: &Issue, cover_by: &[Creator], contents: &[PublishedInfo], pubyear: &[IssueRef])
-@:page(&format!("Fantomen {}/{}", issue.number_str, issue.year), {
+@(year_links: &YearLinks, issue: &IssueDetails, pubyear: &[IssueRef])
+@:page(&format!("Fantomen {}/{}", issue.issue.number_str, issue.issue.year), {
   <p>
-  @if let Some(ref pages) = issue.pages {<span>@pages sidor.</span>}
-  @if let Some(ref price) = issue.price {<span>Pris @price.</span>}
+  @if let Some(ref pages) = issue.issue.pages {<span>@pages sidor.</span>}
+  @if let Some(ref price) = issue.issue.price {<span>Pris @price.</span>}
   <p>Se även @year_links.</p>
 }, {
-  <section class="issue" id="i@issue.number">
+  <section class="issue">
     <header>
-      <h2>Nr @issue.number_str</h2>
-      <div class="info cover@if let Some(b) = issue.cover_best { best@b}">
-	<span class="img"><img src="/c/f@issue.year-@issue.number&#46;jpg" alt=""></span>
+      <h2>Nr @issue.issue.number_str</h2>
+      <div class="info cover@if let Some(b) = issue.issue.cover_best { best@b}">
+	<span class="img"><img src="@issue.issue.cover_url()" alt=""></span>
 	<div class="innerinfo">
-	  @if let Some((last_c, creators)) = cover_by.split_last()
+	  @if let Some((last_c, creators)) = issue.cover_by.split_last()
 	  {<p>Omslag av @for c in creators {@c, }@last_c.</p>}
-	  @if let Some(b) = issue.cover_best {<p>Nr @b i bästa omslag.</p>}
-	  @if issue.pages.is_some() || issue.price.is_some() {<p class="pp">
-	    @if let Some(ref pages) = issue.pages {<span>@pages sidor</span>}
-	    @if let Some(ref price) = issue.price {<span>Pris @price</span>}
+	  @if let Some(b) = issue.issue.cover_best {<p>Nr @b i bästa omslag.</p>}
+	  @if issue.issue.pages.is_some() || issue.issue.price.is_some() {<p class="pp">
+	    @if let Some(ref pages) = issue.issue.pages {<span>@pages sidor</span>}
+	    @if let Some(ref price) = issue.issue.price {<span>Pris @price</span>}
 	  </p>}
 	</div>
       </div>
     </header>
     <div class="content">
-      @for item in contents {
+      @for item in &issue.contents {
       <section class="@item.classnames()" @if let Some(seqno) = item.seqno {data-seq="@seqno"}>
 	@match &item.content {
 	EpisodePart{title, episode, part, best_plac, label} => {
 	@if label != "" {<p class="info label">@label:</p> }
 	<h3><a href="/titles/@title.slug">@title.title</a>@if let Some(ref e) = episode.episode.episode {: @e} @part</h3>
 	@:epmisc(&episode)
-	@if let Some(plac) = best_plac { <p class="info best best@plac">Nummer @plac i omröstningen om bästa äventyr @issue.year.</p>}
+	@if let Some(plac) = best_plac { <p class="info best best@plac">Nummer @plac i omröstningen om bästa äventyr @issue.issue.year.</p>}
 	}
 	Text(article) => {@:artmisc(article)}
 	}
@@ -43,7 +43,7 @@
   </section>
 
   <section>
-    <h2>Alla nummer @issue.year</h2>
+    <h2>Alla nummer @issue.issue.year</h2>
     <p class="yearcovers">@for i in pubyear {
       <a href="/@i.year/@i.number.first()" title="Fa @i.number/@i.year"><img src="@i.cover_url()" alt="@i.number"></a>
     }</p>

--- a/templates/issue.rs.html
+++ b/templates/issue.rs.html
@@ -1,0 +1,51 @@
+@use crate::models::{Creator, Issue, IssueRef};
+@use crate::server::{PublishedInfo, PublishedContent::{EpisodePart, Text}, YearLinks};
+@use super::{artmisc, epmisc, page};
+
+@(year_links: &YearLinks, issue: &Issue, cover_by: &[Creator], contents: &[PublishedInfo], pubyear: &[IssueRef])
+@:page(&format!("Fantomen {}/{}", issue.number_str, issue.year), {
+  <p>
+  @if let Some(ref pages) = issue.pages {<span>@pages sidor.</span>}
+  @if let Some(ref price) = issue.price {<span>Pris @price.</span>}
+  <p>Se även @year_links.</p>
+}, {
+  <section class="issue" id="i@issue.number">
+    <header>
+      <h2>Nr @issue.number_str</h2>
+      <div class="info cover@if let Some(b) = issue.cover_best { best@b}">
+	<span class="img"><img src="/c/f@issue.year-@issue.number&#46;jpg" alt=""></span>
+	<div class="innerinfo">
+	  @if let Some((last_c, creators)) = cover_by.split_last()
+	  {<p>Omslag av @for c in creators {@c, }@last_c.</p>}
+	  @if let Some(b) = issue.cover_best {<p>Nr @b i bästa omslag.</p>}
+	  @if issue.pages.is_some() || issue.price.is_some() {<p class="pp">
+	    @if let Some(ref pages) = issue.pages {<span>@pages sidor</span>}
+	    @if let Some(ref price) = issue.price {<span>Pris @price</span>}
+	  </p>}
+	</div>
+      </div>
+    </header>
+    <div class="content">
+      @for item in contents {
+      <section class="@item.classnames()" @if let Some(seqno) = item.seqno {data-seq="@seqno"}>
+	@match &item.content {
+	EpisodePart{title, episode, part, best_plac, label} => {
+	@if label != "" {<p class="info label">@label:</p> }
+	<h3><a href="/titles/@title.slug">@title.title</a>@if let Some(ref e) = episode.episode.episode {: @e} @part</h3>
+	@:epmisc(&episode)
+	@if let Some(plac) = best_plac { <p class="info best best@plac">Nummer @plac i omröstningen om bästa äventyr @issue.year.</p>}
+	}
+	Text(article) => {@:artmisc(article)}
+	}
+      </section>
+      }
+    </div>
+  </section>
+
+  <section>
+    <h2>Alla nummer @issue.year</h2>
+    <p class="yearcovers">@for i in pubyear {
+      <a href="/@i.year/@i.number.first()" title="Fa @i.number/@i.year"><img src="@i.cover_url()" alt="@i.number"></a>
+    }</p>
+  </section>
+})

--- a/templates/year.rs.html
+++ b/templates/year.rs.html
@@ -10,7 +10,7 @@
     <header>
       <h2>Nr @issue.number_str</h2>
       <div class="info cover@if let Some(b) = issue.cover_best { best@b}">
-	<span class="img"><img src="/c/f@issue.year-@issue.number&#46;jpg" alt=""></span>
+	<span class="img"><img src="@issue.cover_url()" alt=""></span>
 	<div class="innerinfo">
 	  @if let Some((last_c, creators)) = cover_by.split_last()
 	  {<p>Omslag av @for c in creators {@c, }@last_c.</p>}

--- a/templates/year.rs.html
+++ b/templates/year.rs.html
@@ -1,12 +1,11 @@
-@use crate::models::{Creator, Issue};
-@use crate::server::{PublishedInfo, PublishedContent::{EpisodePart, Text}, YearLinks};
+@use crate::server::{IssueDetails, PublishedContent::{EpisodePart, Text}, YearLinks};
 @use super::{artmisc, epmisc, page};
 
-@(year: u16, year_links: &YearLinks, issues: &[(Issue, Vec<Creator>, Vec<PublishedInfo>)])
+@(year: u16, year_links: &YearLinks, issues: &[IssueDetails])
 @:page(&format!("Årgång {}", year), {
   <p>Se även @year_links.</p>
 }, {
-  @for (issue, cover_by, contents) in issues {
+  @for IssueDetails{ issue, cover_by, contents } in issues {
   <section class="issue" id="i@issue.number">
     <header>
       <h2>Nr @issue.number_str</h2>

--- a/templates/year_summary.rs.html
+++ b/templates/year_summary.rs.html
@@ -1,0 +1,32 @@
+@use crate::models::{Creator, Issue};
+@use crate::server::{ContentSummary, YearLinks};
+@use super::page;
+
+@(year: u16, year_links: &YearLinks, issues: &[(Issue, Vec<Creator>, Vec<ContentSummary>)])
+@:page(&format!("Årgång {}", year), {
+  <p>Se även @year_links.</p>
+}, {
+  <div class="yearsummary">
+  @for (issue, cover_by, contents) in issues {
+  <section class="issue" id="i@issue.number">
+    <header>
+      <h2>Nr @issue.number_str</h2>
+      @if issue.pages.is_some() || issue.price.is_some() {<p class="pp">
+	@if let Some(ref pages) = issue.pages {<span>@pages sidor</span>}
+	@if let Some(ref price) = issue.price {<span>Pris @price</span>}
+      </p>}
+      @if let Some((last_c, creators)) = cover_by.split_last()
+      {<p>Omslag av @for c in creators {@c, }@last_c.</p>}
+    </header>
+    <div class="info cover@if let Some(b) = issue.cover_best { best@b}">
+      <a class="img" href="/@issue.year/@issue.number"><img src="/c/f@issue.year-@issue.number&#46;jpg" alt=""></a>
+      @if let Some(b) = issue.cover_best {<p>Nr @b i bästa omslag.</p>}
+    </div>
+    <div class="content"><ul>
+      @for item in contents {<li>@item
+      }
+    </ul></div>
+  </section>
+  }
+  </div>
+})

--- a/templates/year_summary.rs.html
+++ b/templates/year_summary.rs.html
@@ -19,7 +19,7 @@
       {<p>Omslag av @for c in creators {@c, }@last_c.</p>}
     </header>
     <div class="info cover@if let Some(b) = issue.cover_best { best@b}">
-      <a class="img" href="/@issue.year/@issue.number"><img src="/c/f@issue.year-@issue.number&#46;jpg" alt=""></a>
+      <a class="img" href="/@issue.year/@issue.number"><img src="@issue.cover_url()" alt=""></a>
       @if let Some(b) = issue.cover_best {<p>Nr @b i bästa omslag.</p>}
     </div>
     <div class="content"><ul>


### PR DESCRIPTION
Rather than having a long year view with all details, have a year summary view and a detail view for each issue.

(The old all-details-for-a-year view is still around, but only when explicitly requested.)