### PR TITLE
Try deadpool to get to tokio 1.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ ructe = { version = "0.13.4", features = ["sass", "warp02"] }
 [dependencies]
 anyhow = "1.0"
 chrono = "0.4.6"
+deadpool-diesel = { version = "0.1.2", features = ["postgres"] }
 dotenv = "0.15.0"
 env_logger = "0.9.0"
 futures = "0.3" # Must match warp
@@ -20,17 +21,16 @@ log = "0.4.8"
 lazy_static = "1.4.0"
 mime = "0.3"
 regex = "1.5.4"
-reqwest = "0.10.1"
+reqwest = "0.11.4"
 serde = { version = "1.0.88", features = ["derive"] }
 scraper = "0.12.0"
 slug = "0.1.4"
 structopt = { version = "0.3.2", features = ["wrap_help"] }
-tokio = { version = "0.2", features = ["macros"] }
-tokio-diesel = "0.3.0"
-warp = { version = "0.2.0", default-features = false }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
+warp = { version = "0.3.0", default-features = false }
 roxmltree = { version = "0.14", features = ["std"] }
 
 [dependencies.diesel]
 version = "1.4.0"
 default-features = false # get rid of 32-column-tables support
-features = ["chrono", "r2d2", "postgres"]
+features = ["chrono", "postgres"]

--- a/src/dbopt.rs
+++ b/src/dbopt.rs
@@ -1,11 +1,9 @@
+use deadpool_diesel::postgres::{Manager, Pool};
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
-use diesel::r2d2::{ConnectionManager, Pool, PoolError};
-use log::debug;
-use std::time::{Duration, Instant};
 use structopt::StructOpt;
 
-pub type PgPool = Pool<ConnectionManager<PgConnection>>;
+pub type PgPool = Pool;
 
 #[derive(StructOpt)]
 pub struct DbOpt {
@@ -21,14 +19,7 @@ impl DbOpt {
     }
 
     /// Get a database connection pool from the configured url.
-    pub fn get_pool(&self) -> Result<PgPool, PoolError> {
-        let time = Instant::now();
-        let pool = Pool::builder()
-            .min_idle(Some(3))
-            .test_on_check_out(false)
-            .connection_timeout(Duration::from_millis(500))
-            .build(ConnectionManager::new(&self.db_url))?;
-        debug!("Created db pool in {:?}", time.elapsed());
-        Ok(pool)
+    pub fn get_pool(&self) -> PgPool {
+        Pool::new(Manager::new(&self.db_url), 8)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ impl Fanrs {
         match self {
             Fanrs::ReadFiles(args) => args.run(),
             Fanrs::ListIssues(db) => Ok(list_issues(&db.get_db()?)?),
-            Fanrs::RunServer(args) => Ok(args.run().await?),
+            Fanrs::RunServer(args) => Ok(args.run().await),
             Fanrs::FetchCovers(args) => args.run().await,
             Fanrs::CheckStrips(db) => check_strips(&db.get_db()?),
             Fanrs::CountPages(args) => args.run(),
@@ -58,7 +58,7 @@ impl Fanrs {
     }
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "multi_thread", worker_threads = 10)]
 async fn main() -> Result<()> {
     match dotenv() {
         Ok(_) => (),

--- a/src/models/episode.rs
+++ b/src/models/episode.rs
@@ -1,5 +1,4 @@
 use super::{OtherMag, RefKey, Title};
-use crate::server::PgPool;
 use crate::templates::ToHtml;
 use chrono::{Datelike, NaiveDate};
 use diesel::pg::PgConnection;
@@ -7,7 +6,6 @@ use diesel::prelude::*;
 use diesel::result::Error;
 use std::fmt;
 use std::io::{self, Write};
-use tokio_diesel::AsyncError;
 
 #[derive(Debug, Queryable)]
 pub struct Episode {
@@ -149,15 +147,6 @@ impl Episode {
         self.orig_mag_id
             .map(|id| OtherMag::get_by_id(id, db))
             .transpose()
-    }
-    pub async fn load_orig_mag_async(
-        &self,
-        db: &PgPool,
-    ) -> Result<Option<OtherMag>, AsyncError> {
-        match self.orig_mag_id {
-            Some(id) => Ok(Some(OtherMag::get_by_id_async(id, db).await?)),
-            None => Ok(None),
-        }
     }
 }
 

--- a/src/models/other_mag.rs
+++ b/src/models/other_mag.rs
@@ -1,8 +1,6 @@
 use crate::schema::other_mags::dsl as om;
-use crate::server::PgPool;
 use diesel::prelude::*;
 use diesel::result::Error;
-use tokio_diesel::{AsyncError, AsyncRunQueryDsl};
 
 #[derive(Debug, Queryable, PartialOrd, Ord, PartialEq, Eq)]
 pub struct OtherMag {
@@ -17,12 +15,7 @@ impl OtherMag {
     pub fn get_by_id(id: i32, db: &PgConnection) -> Result<OtherMag, Error> {
         om::other_mags.filter(om::id.eq(id)).first::<OtherMag>(db)
     }
-    pub async fn get_by_id_async(
-        id: i32,
-        db: &PgPool,
-    ) -> Result<OtherMag, AsyncError> {
-        om::other_mags.filter(om::id.eq(id)).first_async(db).await
-    }
+
     pub fn get_or_create(
         name: String,
         issue: Option<i16>,

--- a/src/models/refkeyset.rs
+++ b/src/models/refkeyset.rs
@@ -1,10 +1,8 @@
 use super::{Article, Episode, IdRefKey, RefKey};
-use crate::server::PgPool;
 use crate::templates::ToHtml;
 use diesel::prelude::*;
 use diesel::result::Error;
 use std::io::{self, Write};
-use tokio_diesel::{AsyncError, AsyncRunQueryDsl};
 
 #[derive(Debug)]
 pub struct RefKeySet(Vec<RefKey>);
@@ -28,25 +26,6 @@ impl RefKeySet {
                 .collect(),
         ))
     }
-    pub async fn for_article_async(
-        article: &Article,
-        db: &PgPool,
-    ) -> Result<RefKeySet, AsyncError> {
-        use crate::schema::article_refkeys::dsl as ar;
-        use crate::schema::refkeys::{all_columns, dsl as r};
-        Ok(RefKeySet(
-            r::refkeys
-                .inner_join(ar::article_refkeys)
-                .select(all_columns)
-                .filter(ar::article_id.eq(article.id))
-                .order((r::title, r::slug))
-                .load_async::<IdRefKey>(db)
-                .await?
-                .into_iter()
-                .map(|ir| ir.refkey)
-                .collect(),
-        ))
-    }
 
     pub fn for_episode(
         episode: &Episode,
@@ -61,25 +40,6 @@ impl RefKeySet {
                 .filter(er::episode_id.eq(episode.id))
                 .order((r::title, r::slug))
                 .load::<IdRefKey>(db)?
-                .into_iter()
-                .map(|ir| ir.refkey)
-                .collect(),
-        ))
-    }
-    pub async fn for_episode_async(
-        episode: &Episode,
-        db: &PgPool,
-    ) -> Result<RefKeySet, AsyncError> {
-        use crate::schema::episode_refkeys::dsl as er;
-        use crate::schema::refkeys::{all_columns, dsl as r};
-        Ok(RefKeySet(
-            r::refkeys
-                .inner_join(er::episode_refkeys)
-                .select(all_columns)
-                .filter(er::episode_id.eq(episode.id))
-                .order((r::title, r::slug))
-                .load_async::<IdRefKey>(db)
-                .await?
                 .into_iter()
                 .map(|ir| ir.refkey)
                 .collect(),

--- a/src/models/title.rs
+++ b/src/models/title.rs
@@ -2,7 +2,6 @@ use super::{Cloud, CloudItem};
 use crate::schema::episode_parts::dsl as ep;
 use crate::schema::episodes::dsl as e;
 use crate::schema::titles::dsl as t;
-use crate::server::PgPool;
 use crate::templates::ToHtml;
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
@@ -10,7 +9,6 @@ use diesel::result::Error;
 use slug::slugify;
 use std::cmp::Ordering;
 use std::io::{self, Write};
-use tokio_diesel::{AsyncError, AsyncRunQueryDsl};
 
 /// A title of a comic.
 ///
@@ -40,11 +38,11 @@ impl Title {
         }
     }
 
-    pub async fn from_slug(
+    pub fn from_slug(
         slug: String,
-        db: &PgPool,
-    ) -> Result<Title, AsyncError> {
-        t::titles.filter(t::slug.eq(slug)).first_async(db).await
+        db: &PgConnection,
+    ) -> Result<Title, Error> {
+        t::titles.filter(t::slug.eq(slug)).first(db)
     }
 
     pub fn has_daystrip(&self) -> bool {
@@ -54,10 +52,7 @@ impl Title {
     pub fn has_sundays(&self) -> bool {
         SUNDAYS.binary_search(&self.slug.as_ref()).is_ok()
     }
-    pub async fn cloud(
-        num: i64,
-        db: &PgPool,
-    ) -> Result<Cloud<Title>, AsyncError> {
+    pub fn cloud(num: i64, db: &PgConnection) -> Result<Cloud<Title>, Error> {
         use diesel::dsl::sql;
         use diesel::sql_types::Integer;
         let c = sql::<Integer>("cast(count(*) as integer)");
@@ -67,8 +62,7 @@ impl Title {
             .group_by(t::titles::all_columns())
             .order(c.desc())
             .limit(num)
-            .load_async(db)
-            .await?;
+            .load(db)?;
         Ok(Cloud::from_ordered(titles))
     }
 }


### PR DESCRIPTION
Rather than "faking" async diesel operations, use an async pool of plain synchronous database connections.  This makes it more obvious that we areactually blocking on the database operations.  Since the database operations tend to be fast and I use fewer connections than tokio executors, so there should be free executors for truly non-blocking operations.
